### PR TITLE
Add Dockerfile and instructions for running containerized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+RUN mkdir /storj_data
+ADD https://raw.githubusercontent.com/ReneSmeekes/storj_earnings/master/earnings.py /usr/local/bin/
+
+VOLUME /storj_data
+
+ENTRYPOINT [ "python3", "/usr/local/bin/earnings.py", "/storj_data" ]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ Earnings for previous months:
 python earnings.py /path/to/storj/data 2023-03
 ```
 
+## Running in a Docker container
+If you are running your storage node containerized, you may want to also run this script in the same way.
+
+To prepare the container, run:
+```
+curl -sSL https://raw.githubusercontent.com/ReneSmeekes/storj_earnings/master/Dockerfile | docker build -t storj/earnings -
+```
+As long as the image remains cached locally, you don't need to run this command again, until the earnings.py script is updated on GitHub and you want to update to the newest version.
+
+To display your earnings, run:
+```
+docker run --rm -tv /path/to/storj/data:/storj_data storj/earnings
+```
+Make sure to replace /path/to/storj/data to the actual absolute path to your storj data folder.
+
+You may add the year/month at the end of the command to display earnings for previous months:
+```
+docker run --rm -tv /path/to/storj/data:/storj_data storj/earnings 2023-03
+```
+
 ## Example previous months:
 ```
 February 2021 (Version: 13.4.0)


### PR DESCRIPTION
When the storagenode is running in a docker container (for example on a NAS) it is more convenient to run the earnings script in a container as well : this removes the need to install python manually on the host system.

Usage instructions have been added to Readme.md

An improvement to this PR would be to add a github action to build the container and push it to docker hub automatically, but I believe this needs to be done on the base repo ?